### PR TITLE
Remove underscores from ansible hostnames to match instruction sheet

### DIFF
--- a/openstack-client/single_node_with_docker_ansible_client/configuration.yml
+++ b/openstack-client/single_node_with_docker_ansible_client/configuration.yml
@@ -34,7 +34,7 @@
       owner: appuser
       group: appuser
 
-- hosts: prod_server
+- hosts: prodserver
  
   vars_files:
    - setup_var.yml  
@@ -90,7 +90,7 @@
      args: 
       chdir: /model_serving/ci_cd/production_server 
 
-- hosts: dev_server
+- hosts: devserver
   
   vars_files:
    - setup_var.yml


### PR DESCRIPTION
They are shown as devserver and prodserver on the production sheet.

If they are written as on the instruction sheet, the actions for "hosts: all" get applied, but not the others.
