### PR TITLE
use TensorFlow 2.5.3 everywhere

### DIFF
--- a/openstack-client/single_node_with_docker_ansible_client/configuration.yml
+++ b/openstack-client/single_node_with_docker_ansible_client/configuration.yml
@@ -103,4 +103,4 @@
    - name: Install ML packages
      become: true
      pip: 
-      name: tensorflow==2.4.0, keras==2.4.1, numpy, future
+      name: tensorflow==2.5.3, keras==2.4.1, numpy, future


### PR DESCRIPTION
Before:
```
benblamey@bombadil model_serving % grep -r tensorflow==
./ci_cd/production_server/requirements.txt:tensorflow==2.5.3 
./openstack-client/single_node_with_docker_ansible_client/configuration.yml:      name: tensorflow==2.4.0, keras==2.4.1, numpy, future
./openstack-client/single_node_without_docker_client/cloud-cfg.txt: - pip3 install tensorflow==2.5.3
./single_server_with_docker/production_server/requirements.txt:tensorflow==2.5.3

```

After:
```
benblamey@bombadil model_serving % grep -r tensorflow==
./ci_cd/production_server/requirements.txt:tensorflow==2.5.3 
./openstack-client/single_node_with_docker_ansible_client/configuration.yml:      name: tensorflow==2.5.3, keras==2.4.1, numpy, future
./openstack-client/single_node_without_docker_client/cloud-cfg.txt: - pip3 install tensorflow==2.5.3
./single_server_with_docker/production_server/requirements.txt:tensorflow==2.5.3
```