### PR TITLE
Keras and Tensorflow version fixed + docker-compose command replaced

### DIFF
--- a/ci_cd/production_server/Dockerfile
+++ b/ci_cd/production_server/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-buster
-ADD requirements.txt /app/requirements.txt
 WORKDIR /app/
+COPY . .
 RUN pip install -r requirements.txt
 ENTRYPOINT ["python"]
 CMD ["./app.py","--host=0.0.0.0"]

--- a/ci_cd/production_server/docker-compose.yml
+++ b/ci_cd/production_server/docker-compose.yml
@@ -3,14 +3,12 @@ services:
   web:
     build:
       context: .
-      dockerfile: Dockerfile
+      network: host
     restart: always
     ports:
       - "5100:5100"
     depends_on:
       - rabbit
-    volumes:
-      - .:/app
   rabbit:
     hostname: rabbit
     image: rabbitmq:management
@@ -23,11 +21,10 @@ services:
   worker_1:
     build:
       context: .
+      network: host
     hostname: worker_1
     entrypoint: celery
     command: -A workerA worker --loglevel=debug
-    volumes:
-      - .:/app
     links:
       - rabbit
     depends_on:

--- a/ci_cd/production_server/requirements.txt
+++ b/ci_cd/production_server/requirements.txt
@@ -1,7 +1,7 @@
 Flask
 amqp
 celery
-tensorflow==2.5.3 
-keras==2.4.1
+tensorflow==2.10.0 
+keras==2.10.0
 numpy
 future

--- a/openstack-client/single_node_with_docker_ansible_client/configuration.yml
+++ b/openstack-client/single_node_with_docker_ansible_client/configuration.yml
@@ -89,22 +89,9 @@
      apt: pkg=docker-ce state=present update_cache=true allow_unauthenticated=yes
      become: true
 
-   - name: Download docker-compose 
-     become: yes
-     get_url:        
-      url: "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-{{ansible_system}}-{{ansible_architecture}}"
-      dest: /usr/local/bin/docker-compose
-      mode: +x  
-
-   - name: Building containers
-     become: true
-     shell: docker build .
-     args: 
-      chdir: /model_serving/ci_cd/production_server
-
    - name: Running containers
      become: true
-     shell: docker-compose up -d 
+     shell: docker compose up -d 
      args: 
       chdir: /model_serving/ci_cd/production_server 
 
@@ -121,4 +108,4 @@
    - name: Install ML packages
      become: true
      pip: 
-      name: tensorflow==2.5.3, keras==2.4.1, numpy, future
+      name: tensorflow==2.10.0, keras==2.10.0, numpy, future

--- a/openstack-client/single_node_with_docker_client/cloud-cfg.txt
+++ b/openstack-client/single_node_with_docker_client/cloud-cfg.txt
@@ -17,9 +17,9 @@ runcmd:
  - add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
  - apt-get update -y
  - apt-get install -y docker-ce
- - echo "adding docker-compose"
- - curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose
- - chmod +x /usr/local/bin/docker-compose
+# - echo "adding docker-compose"
+# - curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose
+# - chmod +x /usr/local/bin/docker-compose
  - git clone https://github.com/sztoor/model_serving.git
- - docker build -f /model_serving/single_server_with_docker/production_server/Dockerfile . 
- - docker-compose -f /model_serving/single_server_with_docker/production_server/docker-compose.yml up -d 
+# - docker build -f /model_serving/single_server_with_docker/production_server/Dockerfile . 
+ - docker compose -f /model_serving/single_server_with_docker/production_server/docker-compose.yml up -d 

--- a/openstack-client/single_node_without_docker_client/cloud-cfg.txt
+++ b/openstack-client/single_node_without_docker_client/cloud-cfg.txt
@@ -12,7 +12,7 @@ byobu_default: system
 
 runcmd:
  - pip3 install celery
- - pip3 install tensorflow==2.5.3
+ - pip3 install tensorflow==2.10.0
  - pip3 install amqp
  - pip3 install flask
  - pip3 install future

--- a/single_server_with_docker/production_server/Dockerfile
+++ b/single_server_with_docker/production_server/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-buster
-ADD requirements.txt /app/requirements.txt
 WORKDIR /app/
+COPY . .
 RUN pip install -r requirements.txt
 ENTRYPOINT ["python"]
 CMD ["./app.py","--host=0.0.0.0"]

--- a/single_server_with_docker/production_server/docker-compose.yml
+++ b/single_server_with_docker/production_server/docker-compose.yml
@@ -3,14 +3,12 @@ services:
   web:
     build:
       context: .
-      dockerfile: Dockerfile
+      network: host
     restart: always
     ports:
       - "5100:5100"
     depends_on:
       - rabbit
-    volumes:
-      - .:/app
   rabbit:
     hostname: rabbit
     image: rabbitmq:management
@@ -23,11 +21,10 @@ services:
   worker_1:
     build:
       context: .
+      network: host
     hostname: worker_1
     entrypoint: celery
     command: -A workerA worker --loglevel=debug
-    volumes:
-      - .:/app
     links:
       - rabbit
     depends_on:

--- a/single_server_with_docker/production_server/requirements.txt
+++ b/single_server_with_docker/production_server/requirements.txt
@@ -1,7 +1,7 @@
 Flask
 amqp
 celery
-tensorflow==2.5.3
-keras==2.4.1
+tensorflow==2.10.0
+keras==2.10.0
 numpy
 future


### PR DESCRIPTION
Main fixes:
1. Update for dependencies: keras and tensorflow (2.5 => 2.10)
2. All commands of `docker-compose` are replaced by `docker compose` (Two are very similar but some subtle differences exist. And `docker-compose` will be abandoned very soon).
3. MTU problem fixed for docker engine by using host network. 