### PR TITLE
Numpy version specified

### DIFF
--- a/.github/workflows/ci_without_docker.yml
+++ b/.github/workflows/ci_without_docker.yml
@@ -17,7 +17,7 @@ jobs:
         sudo apt update
         sudo apt upgrade -y 
         sudo apt install -y python3-pip python3-dev build-essential rabbitmq-server
-        sudo pip3 install celery tensorflow==2.10.0 amqp flask==2.3.1 future numpy
+        sudo pip3 install celery tensorflow==2.10.0 amqp flask==2.3.1 future numpy<2.0
         git clone https://github.com/sztoor/model_serving.git /tmp/model_serving
     
         timeout --preserve-status 10 celery --workdir=/tmp/model_serving/single_server_without_docker/production_server/ -A workerA worker --detach --loglevel=debug --concurrency=1 -n wkr1@backend

--- a/ci_cd/production_server/requirements.txt
+++ b/ci_cd/production_server/requirements.txt
@@ -3,5 +3,5 @@ amqp
 celery
 tensorflow==2.10.0 
 keras==2.10.0
-numpy
+numpy<2.0
 future

--- a/openstack-client/single_node_with_docker_ansible_client/configuration.yml
+++ b/openstack-client/single_node_with_docker_ansible_client/configuration.yml
@@ -108,4 +108,4 @@
    - name: Install ML packages
      become: true
      pip: 
-      name: tensorflow==2.10.0, keras==2.10.0, numpy, future
+      name: tensorflow==2.10.0, keras==2.10.0, numpy<2.0, future

--- a/openstack-client/single_node_without_docker_client/cloud-cfg.txt
+++ b/openstack-client/single_node_without_docker_client/cloud-cfg.txt
@@ -11,12 +11,7 @@ packages:
 byobu_default: system 
 
 runcmd:
- - pip3 install celery
- - pip3 install tensorflow==2.10.0
- - pip3 install amqp
- - pip3 install flask==2.3.1
- - pip3 install future
- - pip3 install numpy
+ - pip3 install "celery" "tensorflow==2.10.0" "amqp" "flask==2.3.1" "future" "numpy<2.0"
 
  - git clone https://github.com/sztoor/model_serving.git 
  - celery --workdir=/model_serving/single_server_without_docker/production_server -A workerA worker --detach --loglevel=debug --concurrency=1 -n wkr1@backend

--- a/single_server_with_docker/production_server/requirements.txt
+++ b/single_server_with_docker/production_server/requirements.txt
@@ -3,5 +3,5 @@ amqp
 celery
 tensorflow==2.10.0
 keras==2.10.0
-numpy
+numpy<2.0
 future


### PR DESCRIPTION
Numpy of new version is not compatible with tensorflow==2.10.0 any more and we force pip to install numpy<2.0 everywhere.